### PR TITLE
corregir redondeo en módulo nativo de matemática

### DIFF
--- a/src/evaluador.rs
+++ b/src/evaluador.rs
@@ -32,6 +32,7 @@ pub struct FuncionDefinida {
     pub cuerpo: Nodo,
     #[allow(dead_code)]
     pub es_asincrona: bool,
+    pub implementacion_nativa: Option<fn(&mut Evaluador, &[Valor], usize) -> ResultadoQuetzal<Valor>>,
 }
 
 /// Definición de una clase de objeto
@@ -408,7 +409,7 @@ impl Evaluador {
     }
     
     /// Redondea un número de punto flotante para evitar problemas de precisión
-    fn redondear_numero(&self, numero: f64) -> f64 {
+    pub(crate) fn redondear_numero(&self, numero: f64) -> f64 {
         // Redondear a 15 decimales para evitar problemas de precisión de punto flotante
         // pero mantener suficiente precisión para cálculos normales
         let factor = 1e15;
@@ -548,6 +549,7 @@ impl Evaluador {
                     tipo_retorno: tipo_retorno.clone(),
                     cuerpo: (**cuerpo).clone(),
                     es_asincrona: *es_asincrona,
+                    implementacion_nativa: None,
                 };
                 
                 entorno.borrow_mut().definir_funcion(nombre.clone(), funcion)?;
@@ -1629,12 +1631,12 @@ impl Evaluador {
                 let (valor, _) = self.evaluar_con_entorno(argumento, entorno.clone())?;
                 valores_argumentos.push(valor);
             }
-            
+
             // Contar parámetros obligatorios (sin valor por defecto)
             let parametros_obligatorios = funcion.parametros.iter()
                 .filter(|p| p.valor_defecto.is_none())
                 .count();
-            
+
             // Verificar número de argumentos
             if valores_argumentos.len() < parametros_obligatorios || valores_argumentos.len() > funcion.parametros.len() {
                 return Err(ErrorQuetzal::ArgumentosIncorrectos {
@@ -1643,10 +1645,36 @@ impl Evaluador {
                     recibidos: valores_argumentos.len(),
                 });
             }
-            
+
+            // Completar con valores por defecto cuando sea necesario
+            let mut argumentos_completos = Vec::new();
+            for (indice, parametro) in funcion.parametros.iter().enumerate() {
+                if indice < valores_argumentos.len() {
+                    argumentos_completos.push(valores_argumentos[indice].clone());
+                } else if let Some(valor_defecto) = &parametro.valor_defecto {
+                    argumentos_completos.push(valor_defecto.clone());
+                }
+            }
+
+            if argumentos_completos.len() != funcion.parametros.len() {
+                return Err(ErrorQuetzal::ArgumentosIncorrectos {
+                    linea,
+                    esperados: funcion.parametros.len(),
+                    recibidos: valores_argumentos.len(),
+                });
+            }
+
+            if let Some(funcion_nativa) = funcion.implementacion_nativa {
+                let estado_anterior = self.dentro_de_funcion;
+                self.dentro_de_funcion = true;
+                let resultado = funcion_nativa(self, &argumentos_completos, linea)?;
+                self.dentro_de_funcion = estado_anterior;
+                return Ok((resultado, ControlFlujo::Ninguno));
+            }
+
             // Crear entorno para la función
             let entorno_funcion = Rc::new(RefCell::new(Entorno::nuevo_hijo(entorno)));
-            
+
             // Asignar parámetros
             for (i, parametro) in funcion.parametros.iter().enumerate() {
                 let tipo_variable = if parametro.es_variable {
@@ -1654,29 +1682,16 @@ impl Evaluador {
                 } else {
                     TipoVariable::Inmutable
                 };
-                
-                // Determinar el valor a usar
-                let valor = if i < valores_argumentos.len() {
-                    // Usar argumento proporcionado
-                    valores_argumentos[i].clone()
-                } else if let Some(valor_defecto) = &parametro.valor_defecto {
-                    // Usar valor por defecto
-                    valor_defecto.clone()
-                } else {
-                    return Err(ErrorQuetzal::ArgumentosIncorrectos {
-                        linea,
-                        esperados: parametros_obligatorios,
-                        recibidos: valores_argumentos.len(),
-                    });
-                };
-                
+
+                let valor = argumentos_completos[i].clone();
+
                 let variable = Variable::nueva(
                     parametro.nombre.clone(),
                     valor,
                     tipo_variable,
                     parametro.tipo_dato.clone(),
                 );
-                
+
                 entorno_funcion.borrow_mut().definir_variable(parametro.nombre.clone(), variable)?;
             }
             

--- a/src/manejador_modulos.rs
+++ b/src/manejador_modulos.rs
@@ -5,6 +5,7 @@ use crate::analizador_lexico::AnalizadorLexico;
 use crate::analizador_sintactico::{AnalizadorSintactico, Nodo, ElementoImportar};
 use crate::evaluador::{Evaluador, Entorno, FuncionDefinida, ClaseDefinida};
 use crate::errores::{ErrorQuetzal, ResultadoQuetzal};
+use crate::modulos;
 use crate::tipos_datos::Variable;
 use std::collections::HashMap;
 use std::path::{Path, PathBuf};
@@ -35,12 +36,16 @@ pub struct ManejadorModulos {
 /// Información de un módulo cargado
 #[derive(Debug, Clone)]
 pub struct ModuloInfo {
-    /// Ruta absoluta del módulo
-    pub ruta: PathBuf,
+    /// Nombre legible del módulo (ruta o identificador)
+    pub nombre: String,
+    /// Ruta absoluta del módulo cuando proviene de un archivo
+    pub ruta: Option<PathBuf>,
     /// Variables y funciones exportadas por el módulo
     pub exportaciones: HashMap<String, ElementoExportado>,
     /// AST del módulo (para debug y análisis)
-    pub ast: Nodo,
+    pub ast: Option<Nodo>,
+    /// Indica si el módulo es nativo
+    pub es_nativo: bool,
 }
 
 impl ManejadorModulos {
@@ -67,19 +72,29 @@ impl ManejadorModulos {
         evaluador: &mut Evaluador,
         linea: usize,
     ) -> ResultadoQuetzal<()> {
-        // Resolver la ruta del módulo
-        let ruta_absoluta = self.resolver_ruta_modulo(ruta_modulo, linea)?;
-        
-        // Cargar el módulo si no está en caché
-        let ruta_str = ruta_absoluta.to_string_lossy().to_string();
-        
-        if !self.modulos_cargados.contains_key(&ruta_str) {
-            self.cargar_modulo(&ruta_absoluta, evaluador, linea)?;
-        }
-        
+        // Determinar si se trata de un módulo nativo
+        let clave_modulo = if Self::es_modulo_nativo(ruta_modulo) {
+            let nombre_normalizado = Self::normalizar_nombre_modulo(ruta_modulo);
+
+            if !self.modulos_cargados.contains_key(&nombre_normalizado) {
+                self.cargar_modulo_nativo(&nombre_normalizado, ruta_modulo, evaluador, linea)?;
+            }
+
+            nombre_normalizado
+        } else {
+            let ruta_absoluta = self.resolver_ruta_modulo(ruta_modulo, linea)?;
+            let ruta_str = ruta_absoluta.to_string_lossy().to_string();
+
+            if !self.modulos_cargados.contains_key(&ruta_str) {
+                self.cargar_modulo(&ruta_absoluta, evaluador, linea)?;
+            }
+
+            ruta_str
+        };
+
         // Obtener las exportaciones del módulo
         let modulo = self.modulos_cargados
-            .get(&ruta_str)
+            .get(&clave_modulo)
             .ok_or_else(|| ErrorQuetzal::ErrorCargaModulo {
                 linea,
                 ruta: ruta_modulo.to_string(),
@@ -130,6 +145,55 @@ impl ManejadorModulos {
             }
         }
         
+        Ok(())
+    }
+
+    /// Determina si una ruta corresponde a un módulo nativo registrado
+    fn es_modulo_nativo(ruta_modulo: &str) -> bool {
+        Self::normalizar_nombre_modulo(ruta_modulo).starts_with("quetzal/")
+    }
+
+    /// Normaliza el identificador del módulo para evitar inconsistencias
+    fn normalizar_nombre_modulo(ruta_modulo: &str) -> String {
+        ruta_modulo.replace('\\', "/")
+    }
+
+    /// Carga un módulo nativo implementado en Rust
+    fn cargar_modulo_nativo(
+        &mut self,
+        clave_normalizada: &str,
+        nombre_original: &str,
+        evaluador: &mut Evaluador,
+        linea: usize,
+    ) -> ResultadoQuetzal<()> {
+        let registrador = modulos::obtener_registrador(clave_normalizada).ok_or_else(|| {
+            let disponibles = modulos::nombres_registrados();
+            let detalle = if disponibles.is_empty() {
+                "No hay módulos nativos registrados actualmente".to_string()
+            } else {
+                format!("Módulos nativos disponibles: {}", disponibles.join(", "))
+            };
+
+            ErrorQuetzal::ModuloNoEncontrado {
+                linea,
+                ruta: nombre_original.to_string(),
+                detalle,
+            }
+        })?;
+
+        let exportaciones = registrador(evaluador)?;
+
+        let modulo_info = ModuloInfo {
+            nombre: nombre_original.to_string(),
+            ruta: None,
+            exportaciones,
+            ast: None,
+            es_nativo: true,
+        };
+
+        self.modulos_cargados
+            .insert(clave_normalizada.to_string(), modulo_info);
+
         Ok(())
     }
     
@@ -441,15 +505,17 @@ impl ManejadorModulos {
         evaluador.intercambiar_entorno(entorno_anterior);
         
         // Crear información del módulo con las exportaciones recopiladas
+        let nombre_modulo = ruta.to_string_lossy().to_string();
         let modulo_info = ModuloInfo {
-            ruta: ruta.to_path_buf(),
+            nombre: nombre_modulo.clone(),
+            ruta: Some(ruta.to_path_buf()),
             exportaciones: exportaciones_encontradas,
-            ast,
+            ast: Some(ast),
+            es_nativo: false,
         };
-        
+
         // Agregar al caché
-        let ruta_cache = ruta.to_string_lossy().to_string();
-        self.modulos_cargados.insert(ruta_cache, modulo_info);
+        self.modulos_cargados.insert(nombre_modulo, modulo_info);
         
         Ok(())
     }

--- a/src/modulos/matematica.rs
+++ b/src/modulos/matematica.rs
@@ -1,0 +1,100 @@
+// Módulo nativo de ejemplo para Quetzal: operaciones matemáticas básicas
+// El nombre público del módulo es "quetzal/matemática"
+
+use std::collections::HashMap;
+use std::f64::consts::PI;
+
+use crate::analizador_sintactico::{Nodo, Parametro};
+use crate::errores::{ErrorQuetzal, ResultadoQuetzal};
+use crate::evaluador::{Evaluador, FuncionDefinida};
+use crate::manejador_modulos::ElementoExportado;
+use crate::tipos_datos::{TipoVariable, Valor, Variable};
+
+/// Registra todas las exportaciones ofrecidas por el módulo nativo
+pub fn registrar_modulo(
+    evaluador: &mut Evaluador,
+) -> ResultadoQuetzal<HashMap<String, ElementoExportado>> {
+    let mut exportaciones = HashMap::new();
+
+    // Función nativa: sumar(a, b)
+    let parametros_sumar = vec![
+        Parametro {
+            nombre: "a".to_string(),
+            tipo_dato: "número".to_string(),
+            es_variable: false,
+            valor_defecto: None,
+        },
+        Parametro {
+            nombre: "b".to_string(),
+            tipo_dato: "número".to_string(),
+            es_variable: false,
+            valor_defecto: None,
+        },
+    ];
+
+    let funcion_sumar = FuncionDefinida {
+        parametros: parametros_sumar,
+        tipo_retorno: "número".to_string(),
+        cuerpo: Nodo::Literal(Valor::Vacio),
+        es_asincrona: false,
+        implementacion_nativa: Some(funcion_sumar_nativa),
+    };
+
+    exportaciones.insert(
+        "sumar".to_string(),
+        ElementoExportado::Funcion(funcion_sumar),
+    );
+
+    // Constante útil: aproximación de PI
+    // Ajustamos PI con el mismo redondeo que el resto del intérprete
+    let numero_pi = evaluador.redondear_numero(PI);
+
+    let variable_pi = Variable::nueva(
+        "pi_aproximado".to_string(),
+        Valor::Numero(numero_pi),
+        TipoVariable::Inmutable,
+        "número".to_string(),
+    );
+
+    exportaciones.insert(
+        "pi_aproximado".to_string(),
+        ElementoExportado::Variable(variable_pi),
+    );
+
+    Ok(exportaciones)
+}
+
+/// Implementación nativa de la función sumar(a, b)
+fn funcion_sumar_nativa(
+    evaluador: &mut Evaluador,
+    argumentos: &[Valor],
+    linea: usize,
+) -> ResultadoQuetzal<Valor> {
+    if argumentos.len() != 2 {
+        return Err(ErrorQuetzal::ArgumentosIncorrectos {
+            linea,
+            esperados: 2,
+            recibidos: argumentos.len(),
+        });
+    }
+
+    let a = extraer_numero(&argumentos[0], linea, "a")?;
+    let b = extraer_numero(&argumentos[1], linea, "b")?;
+
+    // Redondeamos usando la lógica central del intérprete para evitar errores de acarreo
+    let resultado = evaluador.redondear_numero(a + b);
+
+    Ok(Valor::Numero(resultado))
+}
+
+/// Convierte un valor de Quetzal en un número de punto flotante
+fn extraer_numero(valor: &Valor, linea: usize, nombre: &str) -> ResultadoQuetzal<f64> {
+    match valor {
+        Valor::Numero(numero) => Ok(*numero),
+        Valor::Entero(entero) => Ok(*entero as f64),
+        _ => Err(ErrorQuetzal::ErrorTipo {
+            linea,
+            mensaje: format!("El argumento '{}' debe ser un número", nombre),
+        }),
+    }
+}

--- a/src/modulos/mod.rs
+++ b/src/modulos/mod.rs
@@ -1,0 +1,48 @@
+// Registro centralizado de módulos nativos para el lenguaje Quetzal
+// Permite ampliar las capacidades del intérprete sin modificar el núcleo
+
+use std::collections::HashMap;
+
+use crate::errores::ResultadoQuetzal;
+use crate::evaluador::Evaluador;
+use crate::manejador_modulos::ElementoExportado;
+
+mod matematica;
+
+/// Tipo de función responsable de registrar un módulo nativo
+pub type FuncionRegistroModulo =
+    fn(&mut Evaluador) -> ResultadoQuetzal<HashMap<String, ElementoExportado>>;
+
+/// Descriptor con la información mínima de cada módulo nativo
+struct DescriptorModuloNativo {
+    nombre: &'static str,
+    registrador: FuncionRegistroModulo,
+}
+
+/// Lista estática de módulos nativos disponibles
+const MODULOS_NATIVOS: &[DescriptorModuloNativo] = &[DescriptorModuloNativo {
+    nombre: "quetzal/matemática",
+    registrador: matematica::registrar_modulo,
+}];
+
+/// Obtiene la función registradora asociada a un módulo nativo específico
+pub fn obtener_registrador(nombre: &str) -> Option<FuncionRegistroModulo> {
+    let nombre_normalizado = normalizar_nombre(nombre);
+    MODULOS_NATIVOS
+        .iter()
+        .find(|descriptor| normalizar_nombre(descriptor.nombre) == nombre_normalizado)
+        .map(|descriptor| descriptor.registrador)
+}
+
+/// Devuelve la lista de módulos nativos registrados
+pub fn nombres_registrados() -> Vec<String> {
+    MODULOS_NATIVOS
+        .iter()
+        .map(|descriptor| descriptor.nombre.to_string())
+        .collect()
+}
+
+/// Normaliza el nombre para tratar de forma uniforme rutas con distintas barras
+fn normalizar_nombre(nombre: &str) -> String {
+    nombre.replace('\\', "/")
+}

--- a/src/principal.rs
+++ b/src/principal.rs
@@ -16,6 +16,7 @@ mod tipos_datos;
 mod evaluador;
 mod errores;
 mod consola;
+mod modulos;
 mod manejador_modulos;
 mod maquina_virtual;
 


### PR DESCRIPTION
## Resumen
- expuse el método de redondeo del evaluador para que los módulos nativos puedan reutilizar la misma lógica numérica
- actualicé el módulo `quetzal/matemática` para redondear PI y la función `sumar` con la política propia del lenguaje, evitando errores de acarreo

## Pruebas
- cargo test *(falla por CONNECT 403 al descargar dependencias de crates.io)*

------
https://chatgpt.com/codex/tasks/task_e_68d34fa3922c832fa31332bc10fe5b49