### PR TITLE
feat: soportar permisos desde quetzal.json

### DIFF
--- a/ejemplos/quetzal.json
+++ b/ejemplos/quetzal.json
@@ -1,0 +1,16 @@
+{
+  "versión": "1.0.0",
+  "aplicación": "ejemplo-intérprete-limitado",
+  "permisos": [
+    "red",
+    {
+      "nombre": "sistema-archivos",
+      "alcance": "directorios",
+      "directorios": [
+        "./datos",
+        "./recursos/plantillas",
+        "/var/log/quetzal"
+      ]
+    }
+  ]
+}

--- a/ejemplos/quetzal_sistema_completo.json
+++ b/ejemplos/quetzal_sistema_completo.json
@@ -1,0 +1,11 @@
+{
+  "versión": "1.0.0",
+  "aplicación": "ejemplo-intérprete-sin-restricciones",
+  "permisos": [
+    "red",
+    {
+      "nombre": "sistema-archivos",
+      "alcance": "sistema-completo"
+    }
+  ]
+}

--- a/src/ejecucion/evaluador.rs
+++ b/src/ejecucion/evaluador.rs
@@ -4,6 +4,7 @@
 use crate::analisis::analizador_sintactico::{Nodo, Parametro, SegmentoInterpolacion};
 use crate::datos::tipos_datos::{TipoVariable, Valor, Variable};
 use crate::ejecucion::maquina_virtual::MaquinaVirtualRecursion;
+use crate::infraestructura::configuracion::PermisosEjecucion;
 use crate::infraestructura::consola::CONSOLA_GLOBAL;
 use crate::infraestructura::errores::{ErrorQuetzal, ResultadoQuetzal};
 use crate::infraestructura::manejador_modulos::ManejadorModulos;
@@ -318,6 +319,7 @@ pub struct Evaluador {
     dentro_de_metodo_clase: bool, // Indica si estamos ejecutando un método de clase
     manejador_modulos: Option<ManejadorModulos>,
     ruta_archivo_actual: Option<String>, // Rastrea el archivo que se está evaluando actualmente
+    permisos: PermisosEjecucion,
     vm_recursion: MaquinaVirtualRecursion,
 }
 
@@ -337,6 +339,7 @@ impl Evaluador {
             dentro_de_metodo_clase: false,
             manejador_modulos: None,
             ruta_archivo_actual: None,
+            permisos: PermisosEjecucion::sin_permisos(),
             vm_recursion: MaquinaVirtualRecursion::nueva(),
         }
     }
@@ -344,9 +347,15 @@ impl Evaluador {
     /// Crea un nuevo evaluador con manejador de módulos
     pub fn nuevo_con_modulos(ruta_principal: &str) -> ResultadoQuetzal<Self> {
         let mut evaluador = Self::nuevo();
-        let manejador = ManejadorModulos::nuevo(ruta_principal, evaluador.entorno_global.clone())?;
+        let permisos = PermisosEjecucion::desde_configuracion(ruta_principal)?;
+        let manejador = ManejadorModulos::nuevo(
+            ruta_principal,
+            evaluador.entorno_global.clone(),
+            permisos.clone(),
+        )?;
         evaluador.manejador_modulos = Some(manejador);
         evaluador.ruta_archivo_actual = Some(ruta_principal.to_string());
+        evaluador.permisos = permisos;
         Ok(evaluador)
     }
 
@@ -368,6 +377,11 @@ impl Evaluador {
     /// Toma el manejador de módulos temporalmente
     pub fn tomar_manejador_modulos(&mut self) -> Option<ManejadorModulos> {
         self.manejador_modulos.take()
+    }
+
+    /// Expone los permisos activos para las distintas operaciones.
+    pub fn obtener_permisos(&self) -> &PermisosEjecucion {
+        &self.permisos
     }
 
     /// Compara si dos valores son iguales (para detectar cambios en objetos)

--- a/src/infraestructura/configuracion.rs
+++ b/src/infraestructura/configuracion.rs
@@ -1,0 +1,286 @@
+//! Capa de configuración y permisos para el intérprete Quetzal.
+//!
+//! Este módulo se encarga de leer el archivo `quetzal.json` (si existe)
+//! y traducirlo a una estructura interna que representa los permisos de
+//! ejecución concedidos al programa. La filosofía por defecto es de cero
+//! permisos: si no se encuentra el archivo o si un permiso no se declara
+//! explícitamente, el intérprete asumirá que la acción está prohibida.
+
+use crate::infraestructura::errores::{ErrorQuetzal, ResultadoQuetzal};
+use serde::Deserialize;
+use std::fs;
+use std::path::{Path, PathBuf};
+
+/// Representa el alcance permitido para el acceso al sistema de archivos.
+#[derive(Debug, Clone)]
+pub enum AlcanceSistemaArchivos {
+    /// No existe permiso alguno para interactuar con el sistema de archivos.
+    Denegado,
+    /// El intérprete puede acceder a cualquier ruta del sistema.
+    Todo,
+    /// Solo se puede acceder a los directorios listados (y su contenido).
+    Directorios(Vec<PathBuf>),
+}
+
+/// Permisos resultantes luego de analizar `quetzal.json`.
+#[derive(Debug, Clone)]
+pub struct PermisosEjecucion {
+    permite_red: bool,
+    sistema_archivos: AlcanceSistemaArchivos,
+}
+
+impl PermisosEjecucion {
+    /// Construye un conjunto de permisos sin privilegios.
+    pub fn sin_permisos() -> Self {
+        PermisosEjecucion {
+            permite_red: false,
+            sistema_archivos: AlcanceSistemaArchivos::Denegado,
+        }
+    }
+
+    /// Carga los permisos tomando como referencia la ruta principal del programa.
+    pub fn desde_configuracion(ruta_principal: &str) -> ResultadoQuetzal<Self> {
+        let ruta_programa = Path::new(ruta_principal);
+        let ruta_canonica = ruta_programa
+            .canonicalize()
+            .unwrap_or_else(|_| ruta_programa.to_path_buf());
+        let directorio_base = ruta_canonica
+            .parent()
+            .map(Path::to_path_buf)
+            .unwrap_or_else(|| PathBuf::from("."));
+
+        let ruta_config = directorio_base.join("quetzal.json");
+
+        if !ruta_config.exists() {
+            return Ok(Self::sin_permisos());
+        }
+
+        let contenido =
+            fs::read_to_string(&ruta_config).map_err(|error| ErrorQuetzal::ErrorInterno {
+                mensaje: format!(
+                    "No se pudo leer el archivo de configuración `{}`: {}",
+                    ruta_config.display(),
+                    error
+                ),
+            })?;
+
+        let datos: ArchivoConfiguracion =
+            serde_json::from_str(&contenido).map_err(|error| ErrorQuetzal::ErrorInterno {
+                mensaje: format!(
+                    "No se pudo interpretar el archivo de configuración `{}`: {}",
+                    ruta_config.display(),
+                    error
+                ),
+            })?;
+
+        Self::interpretar_permisos(&datos, &directorio_base)
+    }
+
+    /// Indica si la red está habilitada.
+    pub fn permite_red(&self) -> bool {
+        self.permite_red
+    }
+
+    /// Devuelve el alcance actual del sistema de archivos.
+    pub fn sistema_archivos(&self) -> &AlcanceSistemaArchivos {
+        &self.sistema_archivos
+    }
+
+    /// Verifica que exista permiso general para usar el sistema de archivos.
+    pub fn verificar_uso_sistema_archivos(
+        &self,
+        linea: usize,
+        accion: &str,
+    ) -> ResultadoQuetzal<()> {
+        match &self.sistema_archivos {
+            AlcanceSistemaArchivos::Denegado => Err(ErrorQuetzal::PermisoDenegado {
+                linea,
+                detalle: format!(
+                    "No hay permisos para {} porque el acceso al sistema de archivos está deshabilitado en quetzal.json.",
+                    accion
+                ),
+            }),
+            _ => Ok(()),
+        }
+    }
+
+    /// Verifica que una ruta concreta se encuentre dentro de los permisos concedidos.
+    pub fn verificar_acceso_a_ruta(
+        &self,
+        ruta: &Path,
+        linea: usize,
+        accion: &str,
+    ) -> ResultadoQuetzal<()> {
+        self.verificar_uso_sistema_archivos(linea, accion)?;
+
+        match &self.sistema_archivos {
+            AlcanceSistemaArchivos::Denegado => unreachable!(),
+            AlcanceSistemaArchivos::Todo => Ok(()),
+            AlcanceSistemaArchivos::Directorios(directorios) => {
+                let permitido = directorios
+                    .iter()
+                    .any(|permitido| ruta.starts_with(permitido));
+
+                if permitido {
+                    Ok(())
+                } else {
+                    Err(ErrorQuetzal::PermisoDenegado {
+                        linea,
+                        detalle: format!(
+                            "No hay permisos para {} en `{}`. Actualiza las rutas autorizadas en quetzal.json.",
+                            accion,
+                            ruta.display()
+                        ),
+                    })
+                }
+            }
+        }
+    }
+
+    /// Determina si se puede inspeccionar un directorio sin producir error.
+    pub fn puede_listar_directorio(&self, ruta: &Path) -> bool {
+        match &self.sistema_archivos {
+            AlcanceSistemaArchivos::Denegado => false,
+            AlcanceSistemaArchivos::Todo => true,
+            AlcanceSistemaArchivos::Directorios(directorios) => directorios
+                .iter()
+                .any(|permitido| ruta.starts_with(permitido)),
+        }
+    }
+
+    /// Traduce el archivo de configuración a permisos efectivos.
+    fn interpretar_permisos(
+        datos: &ArchivoConfiguracion,
+        directorio_base: &Path,
+    ) -> ResultadoQuetzal<Self> {
+        let mut permite_red = false;
+        let mut acceso_total = false;
+        let mut directorios_permitidos: Vec<PathBuf> = Vec::new();
+
+        for permiso in &datos.permisos {
+            match permiso {
+                EntradaPermiso::Simple(nombre) => {
+                    let nombre_normalizado = nombre.to_lowercase();
+                    if nombre_normalizado == "red" {
+                        permite_red = true;
+                    } else if nombre_normalizado == "sistema-archivos" {
+                        acceso_total = true;
+                    }
+                }
+                EntradaPermiso::Detallado(detalle) => {
+                    let nombre_normalizado = detalle.nombre.to_lowercase();
+                    if nombre_normalizado == "red" {
+                        permite_red = true;
+                        continue;
+                    }
+
+                    if nombre_normalizado != "sistema-archivos" {
+                        continue;
+                    }
+
+                    let alcance = detalle
+                        .alcance
+                        .as_deref()
+                        .unwrap_or("directorios")
+                        .to_lowercase();
+
+                    match alcance.as_str() {
+                        "todo" => {
+                            acceso_total = true;
+                        }
+                        "directorio" | "directorios" => {
+                            if detalle.directorios.is_empty() {
+                                return Err(ErrorQuetzal::ErrorInterno {
+                                    mensaje: "El permiso 'sistema-archivos' con alcance de directorios requiere la lista 'directorios' en quetzal.json.".to_string(),
+                                });
+                            }
+
+                            for ruta_texto in &detalle.directorios {
+                                let ruta = Self::resolver_directorio(directorio_base, ruta_texto)?;
+                                if !directorios_permitidos
+                                    .iter()
+                                    .any(|existente| existente == &ruta)
+                                {
+                                    directorios_permitidos.push(ruta);
+                                }
+                            }
+                        }
+                        otro => {
+                            return Err(ErrorQuetzal::ErrorInterno {
+                                mensaje: format!(
+                                    "Alcance desconocido '{}' para 'sistema-archivos' en quetzal.json. Usa 'todo' o 'directorios'.",
+                                    otro
+                                ),
+                            });
+                        }
+                    }
+                }
+            }
+        }
+
+        let sistema_archivos = if acceso_total {
+            AlcanceSistemaArchivos::Todo
+        } else if !directorios_permitidos.is_empty() {
+            AlcanceSistemaArchivos::Directorios(directorios_permitidos)
+        } else {
+            AlcanceSistemaArchivos::Denegado
+        };
+
+        Ok(PermisosEjecucion {
+            permite_red,
+            sistema_archivos,
+        })
+    }
+
+    /// Convierte el texto de un directorio en una ruta absoluta canonizada.
+    fn resolver_directorio(base: &Path, entrada: &str) -> ResultadoQuetzal<PathBuf> {
+        let ruta_base = if Path::new(entrada).is_absolute() {
+            PathBuf::from(entrada)
+        } else {
+            base.join(entrada)
+        };
+
+        ruta_base
+            .canonicalize()
+            .map_err(|error| ErrorQuetzal::ErrorInterno {
+                mensaje: format!(
+                    "No se pudo resolver el directorio permitido '{}': {}",
+                    entrada, error
+                ),
+            })
+    }
+}
+
+/// Representación del archivo `quetzal.json` utilizada durante la deserialización.
+#[derive(Debug, Deserialize)]
+struct ArchivoConfiguracion {
+    #[serde(rename = "versión")]
+    #[allow(dead_code)]
+    version: Option<String>,
+    #[serde(rename = "aplicación")]
+    #[allow(dead_code)]
+    aplicacion: Option<String>,
+    #[serde(default)]
+    permisos: Vec<EntradaPermiso>,
+}
+
+/// Permite interpretar tanto permisos simples como estructuras detalladas.
+#[derive(Debug, Deserialize)]
+#[serde(untagged)]
+enum EntradaPermiso {
+    /// Permiso representado únicamente por su nombre (por ejemplo "red").
+    Simple(String),
+    /// Permiso con información adicional.
+    Detallado(PermisoDetallado),
+}
+
+/// Estructura detallada de un permiso dentro de `permisos`.
+#[derive(Debug, Deserialize)]
+struct PermisoDetallado {
+    nombre: String,
+    #[serde(default)]
+    alcance: Option<String>,
+    #[serde(default)]
+    #[serde(alias = "rutas")]
+    directorios: Vec<String>,
+}

--- a/src/infraestructura/errores.rs
+++ b/src/infraestructura/errores.rs
@@ -97,6 +97,9 @@ pub enum ErrorQuetzal {
         sugerencia: String,
     },
 
+    #[error("Permiso denegado en línea {linea}: {detalle}")]
+    PermisoDenegado { linea: usize, detalle: String },
+
     #[error("Ruta de módulo inválida en línea {linea}: '{ruta}' - {razon}")]
     RutaModuloInvalida {
         linea: usize,
@@ -443,6 +446,20 @@ impl ErrorQuetzal {
                     nombre_archivo,
                     nota,
                     sugerencia,
+                );
+            }
+            ErrorQuetzal::PermisoDenegado { linea, detalle } => {
+                let ayuda =
+                    Some("declara los permisos necesarios en quetzal.json dentro del proyecto");
+                self.mostrar_error_formato_rust(
+                    "error",
+                    "E0701",
+                    *linea,
+                    detalle,
+                    codigo_fuente,
+                    nombre_archivo,
+                    None,
+                    ayuda,
                 );
             }
             ErrorQuetzal::ErrorInterno { mensaje } => {

--- a/src/infraestructura/manejador_modulos.rs
+++ b/src/infraestructura/manejador_modulos.rs
@@ -5,6 +5,7 @@ use crate::analisis::analizador_lexico::{AnalizadorLexico, TipoToken};
 use crate::analisis::analizador_sintactico::{AnalizadorSintactico, ElementoImportar, Nodo};
 use crate::datos::tipos_datos::Variable;
 use crate::ejecucion::evaluador::{ClaseDefinida, Entorno, Evaluador, FuncionDefinida};
+use crate::infraestructura::configuracion::PermisosEjecucion;
 use crate::infraestructura::errores::{ErrorQuetzal, ResultadoQuetzal};
 use crate::modulos;
 use std::cell::RefCell;
@@ -31,6 +32,8 @@ pub struct ManejadorModulos {
     ruta_principal: PathBuf,
     /// Entorno global compartido entre módulos
     entorno_global: Rc<RefCell<Entorno>>,
+    /// Permisos activos definidos por el archivo de configuración
+    permisos: PermisosEjecucion,
 }
 
 /// Información de un módulo cargado
@@ -53,6 +56,7 @@ impl ManejadorModulos {
     pub fn nuevo(
         ruta_principal: &str,
         entorno_global: Rc<RefCell<Entorno>>,
+        permisos: PermisosEjecucion,
     ) -> ResultadoQuetzal<Self> {
         let ruta_principal = Path::new(ruta_principal).canonicalize().map_err(|error| {
             ErrorQuetzal::ErrorInterno {
@@ -67,6 +71,7 @@ impl ManejadorModulos {
             modulos_cargados: HashMap::new(),
             ruta_principal,
             entorno_global,
+            permisos,
         })
     }
 
@@ -305,6 +310,11 @@ impl ManejadorModulos {
 
     /// Resuelve la ruta de un módulo relativa al punto de entrada
     fn resolver_ruta_modulo(&self, ruta_modulo: &str, linea: usize) -> ResultadoQuetzal<PathBuf> {
+        self.permisos.verificar_uso_sistema_archivos(
+            linea,
+            "importar módulos desde el sistema de archivos",
+        )?;
+
         // Validaciones básicas de la ruta
         if ruta_modulo.is_empty() {
             return Err(ErrorQuetzal::RutaModuloInvalida {
@@ -335,7 +345,24 @@ impl ManejadorModulos {
                         razon: "Los archivos de módulos deben tener extensión .qz".to_string(),
                     });
                 }
-                return Ok(ruta.to_path_buf());
+                let ruta_canonica =
+                    ruta.canonicalize()
+                        .map_err(|error| ErrorQuetzal::ErrorCargaModulo {
+                            linea,
+                            ruta: ruta_modulo.to_string(),
+                            detalle: format!(
+                                "No se pudo resolver la ruta canónica del módulo: {}",
+                                error
+                            ),
+                        })?;
+
+                self.permisos.verificar_acceso_a_ruta(
+                    &ruta_canonica,
+                    linea,
+                    "importar el módulo",
+                )?;
+
+                return Ok(ruta_canonica);
             } else {
                 return Err(ErrorQuetzal::ModuloNoEncontrado {
                     linea,
@@ -366,22 +393,30 @@ impl ManejadorModulos {
                 });
             }
 
-            ruta_candidata
-                .canonicalize()
-                .map_err(|error| ErrorQuetzal::ErrorCargaModulo {
-                    linea,
-                    ruta: ruta_modulo.to_string(),
-                    detalle: format!("No se pudo resolver la ruta canónica: {}", error),
-                })
+            let ruta_canonica =
+                ruta_candidata
+                    .canonicalize()
+                    .map_err(|error| ErrorQuetzal::ErrorCargaModulo {
+                        linea,
+                        ruta: ruta_modulo.to_string(),
+                        detalle: format!("No se pudo resolver la ruta canónica: {}", error),
+                    })?;
+
+            self.permisos
+                .verificar_acceso_a_ruta(&ruta_canonica, linea, "importar el módulo")?;
+
+            Ok(ruta_canonica)
         } else {
             // Generar sugerencias de archivos .qz cercanos
             let mut archivos_cercanos = Vec::new();
-            if let Ok(entradas) = fs::read_dir(directorio_principal) {
-                for entrada in entradas.flatten() {
-                    if let Some(extension) = entrada.path().extension() {
-                        if extension == "qz" {
-                            if let Some(nombre) = entrada.file_name().to_str() {
-                                archivos_cercanos.push(nombre.to_string());
+            if self.permisos.puede_listar_directorio(directorio_principal) {
+                if let Ok(entradas) = fs::read_dir(directorio_principal) {
+                    for entrada in entradas.flatten() {
+                        if let Some(extension) = entrada.path().extension() {
+                            if extension == "qz" {
+                                if let Some(nombre) = entrada.file_name().to_str() {
+                                    archivos_cercanos.push(nombre.to_string());
+                                }
                             }
                         }
                     }
@@ -431,6 +466,8 @@ impl ManejadorModulos {
         }
 
         // Leer el contenido del archivo
+        self.permisos
+            .verificar_acceso_a_ruta(ruta, linea, "leer el módulo")?;
         let codigo = fs::read_to_string(ruta).map_err(|error| {
             let detalle = match error.kind() {
                 std::io::ErrorKind::NotFound => "El archivo no existe".to_string(),

--- a/src/infraestructura/mod.rs
+++ b/src/infraestructura/mod.rs
@@ -2,6 +2,7 @@
 //!
 //! Este módulo reúne utilidades como la consola de salida, el sistema de
 //! errores estructurados y el manejador de módulos externos.
+pub mod configuracion;
 pub mod consola;
 pub mod errores;
 pub mod manejador_modulos;


### PR DESCRIPTION
## Resumen
- agregar lector de quetzal.json que define permisos de red y sistema de archivos con soporte de directorios específicos
- propagar los permisos al evaluador y al manejador de módulos para bloquear importaciones sin autorización y emitir errores claros
- incorporar un nuevo error `PermisoDenegado` y exponer los permisos activos para futuras extensiones

## Pruebas
- cargo fmt
- cargo test *(falló por restricciones de red al descargar dependencias)*

------
https://chatgpt.com/codex/tasks/task_e_68d362249720832f91abf1680bd625ff