### PR TITLE
Refactorizar registro de métodos nativos de Matemática

### DIFF
--- a/ejemplos/modulo_matematicas.qz
+++ b/ejemplos/modulo_matematicas.qz
@@ -1,0 +1,50 @@
+importar {
+    Matemática
+} desde "quetzal/matemática"
+
+// Operaciones aritméticas básicas
+número suma = Matemática.sumar(12.5, 7.3)
+número diferencia = Matemática.restar(10, 4.25)
+número producto = Matemática.multiplicar(6, 3.5)
+número cociente = Matemática.dividir(42, 6)
+número potencia = Matemática.potencia(2, 10)
+
+// Funciones avanzadas
+número radianes = Matemática.grados_a_radianes(90)
+número seno = Matemática.seno(radianes)
+número hipotenusa = Matemática.hipotenusa(3, 4)
+número log_base = Matemática.logaritmo_base(256, 2)
+número valor_exponencial = Matemática.exponencial(1)
+
+// Estadística sencilla
+lista<número> mediciones = [2.5, 5.0, 10.5, 13.0]
+número promedio = Matemática.promedio(mediciones)
+número valor_maximo = Matemática.maximo(mediciones)
+número valor_minimo = Matemática.minimo(mediciones)
+número suma_total = Matemática.suma_total(mediciones)
+número producto_total = Matemática.producto_total(mediciones)
+
+// Uso de constantes y redondeo
+número mitad_pi = Matemática.PI / 2
+número seno_mitad_pi = Matemática.seno(mitad_pi)
+número redondeado = Matemática.redondear(3.141592, 4)
+
+consola.mostrar(t"PI: {Matemática.PI}")
+consola.mostrar(t"TAU: {Matemática.TAU}")
+consola.mostrar(t"E: {Matemática.E}")
+consola.mostrar(t"Suma: {suma}")
+consola.mostrar(t"Diferencia: {diferencia}")
+consola.mostrar(t"Producto: {producto}")
+consola.mostrar(t"Cociente: {cociente}")
+consola.mostrar(t"2^10: {potencia}")
+consola.mostrar(t"Seno 90°: {seno}")
+consola.mostrar(t"Hipotenusa (3,4): {hipotenusa}")
+consola.mostrar(t"Log base 2 de 256: {log_base}")
+consola.mostrar(t"e^1: {valor_exponencial}")
+consola.mostrar(t"Promedio: {promedio}")
+consola.mostrar(t"Máximo: {valor_maximo}")
+consola.mostrar(t"Mínimo: {valor_minimo}")
+consola.mostrar(t"Suma total: {suma_total}")
+consola.mostrar(t"Producto total: {producto_total}")
+consola.mostrar(t"Seno de PI/2: {seno_mitad_pi}")
+consola.mostrar(t"Redondeo a 4 decimales: {redondeado}")

--- a/ejemplos/modulos_nativos_de_quetzal.qz
+++ b/ejemplos/modulos_nativos_de_quetzal.qz
@@ -1,5 +1,7 @@
 importar {
-    sumar
+    Matemática
 } desde "quetzal/matemática"
 
-consola.mostrar(t"El resultado de 2 + 3 es: {sumar(2, 3)}")
+número suma = Matemática.sumar(2, 3)
+consola.mostrar(t"El resultado de 2 + 3 es: {suma}")
+consola.mostrar(t"Valor de PI: {Matemática.PI}")

--- a/src/ejecucion/evaluador.rs
+++ b/src/ejecucion/evaluador.rs
@@ -62,6 +62,28 @@ pub enum ControlFlujo {
     Continuar,
 }
 
+/// Resultado producido por un método nativo registrado para un objeto
+pub struct ResultadoMetodoObjetoNativo {
+    pub valor_retorno: Valor,
+    pub control_flujo: ControlFlujo,
+    pub reemplazo_objeto: Option<Valor>,
+}
+
+impl ResultadoMetodoObjetoNativo {
+    /// Construye un resultado simple sin reemplazar el objeto original
+    pub fn sin_cambios(valor_retorno: Valor) -> Self {
+        ResultadoMetodoObjetoNativo {
+            valor_retorno,
+            control_flujo: ControlFlujo::Ninguno,
+            reemplazo_objeto: None,
+        }
+    }
+}
+
+/// Tipo de función que implementa un método nativo asociado a un objeto
+pub type MetodoObjetoNativo =
+    fn(&mut Evaluador, &Valor, &[Valor], usize) -> ResultadoQuetzal<ResultadoMetodoObjetoNativo>;
+
 impl Entorno {
     /// Crea un nuevo entorno vacío
     pub fn nuevo() -> Self {
@@ -321,6 +343,7 @@ pub struct Evaluador {
     ruta_archivo_actual: Option<String>, // Rastrea el archivo que se está evaluando actualmente
     permisos: PermisosEjecucion,
     vm_recursion: MaquinaVirtualRecursion,
+    metodos_objetos_nativos: HashMap<String, HashMap<String, MetodoObjetoNativo>>,
 }
 
 impl Evaluador {
@@ -341,6 +364,7 @@ impl Evaluador {
             ruta_archivo_actual: None,
             permisos: PermisosEjecucion::sin_permisos(),
             vm_recursion: MaquinaVirtualRecursion::nueva(),
+            metodos_objetos_nativos: HashMap::new(),
         }
     }
 
@@ -377,6 +401,19 @@ impl Evaluador {
     /// Toma el manejador de módulos temporalmente
     pub fn tomar_manejador_modulos(&mut self) -> Option<ManejadorModulos> {
         self.manejador_modulos.take()
+    }
+
+    /// Registra un método nativo para un objeto expuesto por un módulo
+    pub fn registrar_metodo_objeto_nativo(
+        &mut self,
+        nombre_objeto: &str,
+        nombre_metodo: &str,
+        implementacion: MetodoObjetoNativo,
+    ) {
+        self.metodos_objetos_nativos
+            .entry(nombre_objeto.to_string())
+            .or_insert_with(HashMap::new)
+            .insert(nombre_metodo.to_string(), implementacion);
     }
 
     /// Expone los permisos activos para las distintas operaciones.
@@ -4290,8 +4327,15 @@ impl Evaluador {
         argumentos: &[Valor],
         linea: usize,
     ) -> ResultadoQuetzal<(Valor, ControlFlujo)> {
-        // Manejar métodos específicos de objetos Quetzal
+        // Verificar si existe un método nativo registrado para este objeto
         if let Valor::Objeto { clase, .. } = valor {
+            if let Some(metodos) = self.metodos_objetos_nativos.get(clase) {
+                if let Some(implementacion) = metodos.get(metodo) {
+                    let resultado = implementacion(self, valor, argumentos, linea)?;
+                    return Ok((resultado.valor_retorno, resultado.control_flujo));
+                }
+            }
+
             // Buscar la clase para obtener los métodos disponibles
             let clase_def = {
                 let entorno_ref = self.entorno_global.borrow();
@@ -5952,8 +5996,26 @@ impl Evaluador {
         entorno: Rc<RefCell<Entorno>>,
         nombre_variable: Option<String>,
     ) -> ResultadoQuetzal<(Valor, ControlFlujo)> {
-        // Manejar métodos específicos de objetos Quetzal
+        // Verificar primero si existe una implementación nativa
         if let Valor::Objeto { clase, .. } = valor {
+            if let Some(metodos) = self.metodos_objetos_nativos.get(clase) {
+                if let Some(implementacion) = metodos.get(metodo) {
+                    let resultado = implementacion(self, valor, argumentos, linea)?;
+
+                    if let (Some(nombre_var), Some(nuevo_objeto)) =
+                        (nombre_variable, resultado.reemplazo_objeto.clone())
+                    {
+                        let mut entorno_mut = entorno.borrow_mut();
+                        if let Some(variable_existente) = entorno_mut.variables.get_mut(&nombre_var)
+                        {
+                            variable_existente.valor = nuevo_objeto;
+                        }
+                    }
+
+                    return Ok((resultado.valor_retorno, resultado.control_flujo));
+                }
+            }
+
             // Buscar la clase para obtener los métodos disponibles
             let clase_def = {
                 let entorno_ref = self.entorno_global.borrow();

--- a/src/modulos/matematica.rs
+++ b/src/modulos/matematica.rs
@@ -1,14 +1,52 @@
-// Módulo nativo de ejemplo para Quetzal: operaciones matemáticas básicas
-// El nombre público del módulo es "quetzal/matemática"
+// Módulo nativo de matemáticas para Quetzal
+// Proporciona constantes y un objeto utilitario con operaciones matemáticas
 
 use std::collections::HashMap;
-use std::f64::consts::PI;
+use std::f64::consts::{E, PI, TAU};
 
-use crate::analisis::analizador_sintactico::{Nodo, Parametro};
 use crate::datos::tipos_datos::{TipoVariable, Valor, Variable};
-use crate::ejecucion::evaluador::{Evaluador, FuncionDefinida};
+use crate::ejecucion::evaluador::{Evaluador, MetodoObjetoNativo, ResultadoMetodoObjetoNativo};
 use crate::infraestructura::errores::{ErrorQuetzal, ResultadoQuetzal};
 use crate::infraestructura::manejador_modulos::ElementoExportado;
+
+/// Nombre del objeto expuesto por el módulo de matemáticas
+const NOMBRE_OBJETO_MATEMATICA: &str = "Matemática";
+
+/// Lista de métodos disponibles en el objeto Matemática
+const METODOS_MATEMATICA: &[&str] = &[
+    "sumar",
+    "restar",
+    "multiplicar",
+    "dividir",
+    "modulo",
+    "potencia",
+    "raiz",
+    "raiz_cuadrada",
+    "valor_absoluto",
+    "redondear",
+    "piso",
+    "techo",
+    "truncar",
+    "signo",
+    "seno",
+    "coseno",
+    "tangente",
+    "arcoseno",
+    "arcocoseno",
+    "arcotangente",
+    "hipotenusa",
+    "logaritmo",
+    "logaritmo_base",
+    "logaritmo10",
+    "exponencial",
+    "maximo",
+    "minimo",
+    "promedio",
+    "suma_total",
+    "producto_total",
+    "grados_a_radianes",
+    "radianes_a_grados",
+];
 
 /// Registra todas las exportaciones ofrecidas por el módulo nativo
 pub fn registrar_modulo(
@@ -16,85 +54,743 @@ pub fn registrar_modulo(
 ) -> ResultadoQuetzal<HashMap<String, ElementoExportado>> {
     let mut exportaciones = HashMap::new();
 
-    // Función nativa: sumar(a, b)
-    let parametros_sumar = vec![
-        Parametro {
-            nombre: "a".to_string(),
-            tipo_dato: "número".to_string(),
-            es_variable: false,
-            valor_defecto: None,
-        },
-        Parametro {
-            nombre: "b".to_string(),
-            tipo_dato: "número".to_string(),
-            es_variable: false,
-            valor_defecto: None,
-        },
-    ];
+    registrar_metodos_matematica(evaluador);
 
-    let funcion_sumar = FuncionDefinida {
-        parametros: parametros_sumar,
-        tipo_retorno: "número".to_string(),
-        cuerpo: Nodo::Literal(Valor::Vacio),
-        es_asincrona: false,
-        implementacion_nativa: Some(funcion_sumar_nativa),
-    };
+    let objeto_matematica = construir_objeto_matematica(evaluador);
 
     exportaciones.insert(
-        "sumar".to_string(),
-        ElementoExportado::Funcion(funcion_sumar),
-    );
-
-    // Constante útil: aproximación de PI
-    // Ajustamos PI con el mismo redondeo que el resto del intérprete
-    let numero_pi = evaluador.redondear_numero(PI);
-
-    let variable_pi = Variable::nueva(
-        "pi_aproximado".to_string(),
-        Valor::Numero(numero_pi),
-        TipoVariable::Inmutable,
-        "número".to_string(),
-    );
-
-    exportaciones.insert(
-        "pi_aproximado".to_string(),
-        ElementoExportado::Variable(variable_pi),
+        NOMBRE_OBJETO_MATEMATICA.to_string(),
+        ElementoExportado::Instancia(objeto_matematica),
     );
 
     Ok(exportaciones)
 }
 
-/// Implementación nativa de la función sumar(a, b)
-fn funcion_sumar_nativa(
+/// Registra las implementaciones nativas para cada método del objeto Matemática
+fn registrar_metodos_matematica(evaluador: &mut Evaluador) {
+    for (nombre, implementacion) in METODOS_DISPONIBLES.iter() {
+        evaluador.registrar_metodo_objeto_nativo(NOMBRE_OBJETO_MATEMATICA, nombre, *implementacion);
+    }
+}
+
+/// Listado de métodos disponibles junto con su implementación en Rust
+const METODOS_DISPONIBLES: &[(&str, MetodoObjetoNativo)] = &[
+    ("sumar", metodo_sumar),
+    ("restar", metodo_restar),
+    ("multiplicar", metodo_multiplicar),
+    ("dividir", metodo_dividir),
+    ("modulo", metodo_modulo),
+    ("potencia", metodo_potencia),
+    ("raiz", metodo_raiz),
+    ("raiz_cuadrada", metodo_raiz_cuadrada),
+    ("valor_absoluto", metodo_valor_absoluto),
+    ("redondear", metodo_redondear),
+    ("piso", metodo_piso),
+    ("techo", metodo_techo),
+    ("truncar", metodo_truncar),
+    ("signo", metodo_signo),
+    ("seno", metodo_seno),
+    ("coseno", metodo_coseno),
+    ("tangente", metodo_tangente),
+    ("arcoseno", metodo_arcoseno),
+    ("arcocoseno", metodo_arcocoseno),
+    ("arcotangente", metodo_arcotangente),
+    ("hipotenusa", metodo_hipotenusa),
+    ("logaritmo", metodo_logaritmo),
+    ("logaritmo_base", metodo_logaritmo_base),
+    ("logaritmo10", metodo_logaritmo10),
+    ("exponencial", metodo_exponencial),
+    ("maximo", metodo_maximo),
+    ("minimo", metodo_minimo),
+    ("promedio", metodo_promedio),
+    ("suma_total", metodo_suma_total),
+    ("producto_total", metodo_producto_total),
+    ("grados_a_radianes", metodo_grados_a_radianes),
+    ("radianes_a_grados", metodo_radianes_a_grados),
+];
+
+fn metodo_sumar(
     evaluador: &mut Evaluador,
+    _objeto: &Valor,
     argumentos: &[Valor],
     linea: usize,
-) -> ResultadoQuetzal<Valor> {
-    if argumentos.len() != 2 {
-        return Err(ErrorQuetzal::ArgumentosIncorrectos {
+) -> ResultadoQuetzal<ResultadoMetodoObjetoNativo> {
+    verificar_argumentos_exactos(argumentos, 2, linea)?;
+    let a = extraer_numero(argumentos, 0, linea, "primer argumento")?;
+    let b = extraer_numero(argumentos, 1, linea, "segundo argumento")?;
+    Ok(respuesta_numero(evaluador, a + b))
+}
+
+fn metodo_restar(
+    evaluador: &mut Evaluador,
+    _objeto: &Valor,
+    argumentos: &[Valor],
+    linea: usize,
+) -> ResultadoQuetzal<ResultadoMetodoObjetoNativo> {
+    verificar_argumentos_exactos(argumentos, 2, linea)?;
+    let minuendo = extraer_numero(argumentos, 0, linea, "minuendo")?;
+    let sustraendo = extraer_numero(argumentos, 1, linea, "sustraendo")?;
+    Ok(respuesta_numero(evaluador, minuendo - sustraendo))
+}
+
+fn metodo_multiplicar(
+    evaluador: &mut Evaluador,
+    _objeto: &Valor,
+    argumentos: &[Valor],
+    linea: usize,
+) -> ResultadoQuetzal<ResultadoMetodoObjetoNativo> {
+    verificar_argumentos_exactos(argumentos, 2, linea)?;
+    let a = extraer_numero(argumentos, 0, linea, "primer argumento")?;
+    let b = extraer_numero(argumentos, 1, linea, "segundo argumento")?;
+    Ok(respuesta_numero(evaluador, a * b))
+}
+
+fn metodo_dividir(
+    evaluador: &mut Evaluador,
+    _objeto: &Valor,
+    argumentos: &[Valor],
+    linea: usize,
+) -> ResultadoQuetzal<ResultadoMetodoObjetoNativo> {
+    verificar_argumentos_exactos(argumentos, 2, linea)?;
+    let dividendo = extraer_numero(argumentos, 0, linea, "dividendo")?;
+    let divisor = extraer_numero(argumentos, 1, linea, "divisor")?;
+
+    if divisor.abs() < f64::EPSILON {
+        return Err(ErrorQuetzal::DivisionPorCero { linea });
+    }
+
+    Ok(respuesta_numero(evaluador, dividendo / divisor))
+}
+
+fn metodo_modulo(
+    evaluador: &mut Evaluador,
+    _objeto: &Valor,
+    argumentos: &[Valor],
+    linea: usize,
+) -> ResultadoQuetzal<ResultadoMetodoObjetoNativo> {
+    verificar_argumentos_exactos(argumentos, 2, linea)?;
+    let dividendo = extraer_numero(argumentos, 0, linea, "dividendo")?;
+    let divisor = extraer_numero(argumentos, 1, linea, "divisor")?;
+
+    if divisor.abs() < f64::EPSILON {
+        return Err(ErrorQuetzal::DivisionPorCero { linea });
+    }
+
+    Ok(respuesta_numero(evaluador, dividendo % divisor))
+}
+
+fn metodo_potencia(
+    evaluador: &mut Evaluador,
+    _objeto: &Valor,
+    argumentos: &[Valor],
+    linea: usize,
+) -> ResultadoQuetzal<ResultadoMetodoObjetoNativo> {
+    verificar_argumentos_exactos(argumentos, 2, linea)?;
+    let base = extraer_numero(argumentos, 0, linea, "base")?;
+    let exponente = extraer_numero(argumentos, 1, linea, "exponente")?;
+    let resultado = base.powf(exponente);
+
+    if !resultado.is_finite() {
+        return Err(ErrorQuetzal::ErrorEjecucion {
             linea,
-            esperados: 2,
-            recibidos: argumentos.len(),
+            mensaje: "El resultado de 'potencia' no es un número finito".to_string(),
         });
     }
 
-    let a = extraer_numero(&argumentos[0], linea, "a")?;
-    let b = extraer_numero(&argumentos[1], linea, "b")?;
-
-    // Redondeamos usando la lógica central del intérprete para evitar errores de acarreo
-    let resultado = evaluador.redondear_numero(a + b);
-
-    Ok(Valor::Numero(resultado))
+    Ok(respuesta_numero(evaluador, resultado))
 }
 
-/// Convierte un valor de Quetzal en un número de punto flotante
-fn extraer_numero(valor: &Valor, linea: usize, nombre: &str) -> ResultadoQuetzal<f64> {
-    match valor {
-        Valor::Numero(numero) => Ok(*numero),
-        Valor::Entero(entero) => Ok(*entero as f64),
+fn metodo_raiz(
+    evaluador: &mut Evaluador,
+    _objeto: &Valor,
+    argumentos: &[Valor],
+    linea: usize,
+) -> ResultadoQuetzal<ResultadoMetodoObjetoNativo> {
+    verificar_argumentos_exactos(argumentos, 2, linea)?;
+    let valor = extraer_numero(argumentos, 0, linea, "valor")?;
+
+    if valor < 0.0 {
+        return Err(ErrorQuetzal::ErrorEjecucion {
+            linea,
+            mensaje: "No se puede calcular la raíz de un número negativo".to_string(),
+        });
+    }
+
+    let indice = extraer_entero(argumentos, 1, linea, "índice de la raíz")?;
+
+    if indice == 0 {
+        return Err(ErrorQuetzal::ErrorEjecucion {
+            linea,
+            mensaje: "El índice de la raíz no puede ser cero".to_string(),
+        });
+    }
+
+    if valor == 0.0 {
+        return Ok(respuesta_numero(evaluador, 0.0));
+    }
+
+    if indice < 0 {
+        return Err(ErrorQuetzal::ErrorEjecucion {
+            linea,
+            mensaje: "El índice de la raíz debe ser positivo".to_string(),
+        });
+    }
+
+    let indice_f64 = indice as f64;
+    let resultado = valor.powf(1.0 / indice_f64);
+
+    if resultado.is_nan() || !resultado.is_finite() {
+        return Err(ErrorQuetzal::ErrorEjecucion {
+            linea,
+            mensaje: "El resultado de la raíz no es un número válido".to_string(),
+        });
+    }
+
+    Ok(respuesta_numero(evaluador, resultado))
+}
+
+fn metodo_raiz_cuadrada(
+    evaluador: &mut Evaluador,
+    _objeto: &Valor,
+    argumentos: &[Valor],
+    linea: usize,
+) -> ResultadoQuetzal<ResultadoMetodoObjetoNativo> {
+    verificar_argumentos_exactos(argumentos, 1, linea)?;
+    let valor = extraer_numero(argumentos, 0, linea, "valor")?;
+
+    if valor < 0.0 {
+        return Err(ErrorQuetzal::ErrorEjecucion {
+            linea,
+            mensaje: "No se puede calcular la raíz cuadrada de un número negativo".to_string(),
+        });
+    }
+
+    Ok(respuesta_numero(evaluador, valor.sqrt()))
+}
+
+fn metodo_valor_absoluto(
+    evaluador: &mut Evaluador,
+    _objeto: &Valor,
+    argumentos: &[Valor],
+    linea: usize,
+) -> ResultadoQuetzal<ResultadoMetodoObjetoNativo> {
+    verificar_argumentos_exactos(argumentos, 1, linea)?;
+    let valor = extraer_numero(argumentos, 0, linea, "valor")?;
+    Ok(respuesta_numero(evaluador, valor.abs()))
+}
+
+fn metodo_redondear(
+    evaluador: &mut Evaluador,
+    _objeto: &Valor,
+    argumentos: &[Valor],
+    linea: usize,
+) -> ResultadoQuetzal<ResultadoMetodoObjetoNativo> {
+    if argumentos.is_empty() || argumentos.len() > 2 {
+        return Err(ErrorQuetzal::ErrorEjecucion {
+            linea,
+            mensaje: "El método 'redondear' acepta uno o dos argumentos".to_string(),
+        });
+    }
+
+    let valor = extraer_numero(argumentos, 0, linea, "valor")?;
+
+    let decimales = if argumentos.len() == 2 {
+        extraer_entero(argumentos, 1, linea, "decimales")?
+    } else {
+        0
+    };
+
+    if decimales < 0 {
+        return Err(ErrorQuetzal::ErrorEjecucion {
+            linea,
+            mensaje: "El número de decimales no puede ser negativo".to_string(),
+        });
+    }
+
+    let factor = 10_f64.powi(decimales as i32);
+    let resultado = (valor * factor).round() / factor;
+    Ok(respuesta_numero(evaluador, resultado))
+}
+
+fn metodo_piso(
+    evaluador: &mut Evaluador,
+    _objeto: &Valor,
+    argumentos: &[Valor],
+    linea: usize,
+) -> ResultadoQuetzal<ResultadoMetodoObjetoNativo> {
+    verificar_argumentos_exactos(argumentos, 1, linea)?;
+    let valor = extraer_numero(argumentos, 0, linea, "valor")?;
+    Ok(respuesta_numero(evaluador, valor.floor()))
+}
+
+fn metodo_techo(
+    evaluador: &mut Evaluador,
+    _objeto: &Valor,
+    argumentos: &[Valor],
+    linea: usize,
+) -> ResultadoQuetzal<ResultadoMetodoObjetoNativo> {
+    verificar_argumentos_exactos(argumentos, 1, linea)?;
+    let valor = extraer_numero(argumentos, 0, linea, "valor")?;
+    Ok(respuesta_numero(evaluador, valor.ceil()))
+}
+
+fn metodo_truncar(
+    evaluador: &mut Evaluador,
+    _objeto: &Valor,
+    argumentos: &[Valor],
+    linea: usize,
+) -> ResultadoQuetzal<ResultadoMetodoObjetoNativo> {
+    verificar_argumentos_exactos(argumentos, 1, linea)?;
+    let valor = extraer_numero(argumentos, 0, linea, "valor")?;
+    Ok(respuesta_numero(evaluador, valor.trunc()))
+}
+
+fn metodo_signo(
+    evaluador: &mut Evaluador,
+    _objeto: &Valor,
+    argumentos: &[Valor],
+    linea: usize,
+) -> ResultadoQuetzal<ResultadoMetodoObjetoNativo> {
+    verificar_argumentos_exactos(argumentos, 1, linea)?;
+    let valor = extraer_numero(argumentos, 0, linea, "valor")?;
+    let signo = if valor > 0.0 {
+        1.0
+    } else if valor < 0.0 {
+        -1.0
+    } else {
+        0.0
+    };
+    Ok(respuesta_numero(evaluador, signo))
+}
+
+fn metodo_seno(
+    evaluador: &mut Evaluador,
+    _objeto: &Valor,
+    argumentos: &[Valor],
+    linea: usize,
+) -> ResultadoQuetzal<ResultadoMetodoObjetoNativo> {
+    verificar_argumentos_exactos(argumentos, 1, linea)?;
+    let radianes = extraer_numero(argumentos, 0, linea, "radianes")?;
+    Ok(respuesta_numero(evaluador, radianes.sin()))
+}
+
+fn metodo_coseno(
+    evaluador: &mut Evaluador,
+    _objeto: &Valor,
+    argumentos: &[Valor],
+    linea: usize,
+) -> ResultadoQuetzal<ResultadoMetodoObjetoNativo> {
+    verificar_argumentos_exactos(argumentos, 1, linea)?;
+    let radianes = extraer_numero(argumentos, 0, linea, "radianes")?;
+    Ok(respuesta_numero(evaluador, radianes.cos()))
+}
+
+fn metodo_tangente(
+    evaluador: &mut Evaluador,
+    _objeto: &Valor,
+    argumentos: &[Valor],
+    linea: usize,
+) -> ResultadoQuetzal<ResultadoMetodoObjetoNativo> {
+    verificar_argumentos_exactos(argumentos, 1, linea)?;
+    let radianes = extraer_numero(argumentos, 0, linea, "radianes")?;
+    Ok(respuesta_numero(evaluador, radianes.tan()))
+}
+
+fn metodo_arcoseno(
+    evaluador: &mut Evaluador,
+    _objeto: &Valor,
+    argumentos: &[Valor],
+    linea: usize,
+) -> ResultadoQuetzal<ResultadoMetodoObjetoNativo> {
+    verificar_argumentos_exactos(argumentos, 1, linea)?;
+    let valor = extraer_numero(argumentos, 0, linea, "valor")?;
+    if !(valor >= -1.0 && valor <= 1.0) {
+        return Err(ErrorQuetzal::ErrorEjecucion {
+            linea,
+            mensaje: "El argumento de 'arcoseno' debe estar entre -1 y 1".to_string(),
+        });
+    }
+    Ok(respuesta_numero(evaluador, valor.asin()))
+}
+
+fn metodo_arcocoseno(
+    evaluador: &mut Evaluador,
+    _objeto: &Valor,
+    argumentos: &[Valor],
+    linea: usize,
+) -> ResultadoQuetzal<ResultadoMetodoObjetoNativo> {
+    verificar_argumentos_exactos(argumentos, 1, linea)?;
+    let valor = extraer_numero(argumentos, 0, linea, "valor")?;
+    if !(valor >= -1.0 && valor <= 1.0) {
+        return Err(ErrorQuetzal::ErrorEjecucion {
+            linea,
+            mensaje: "El argumento de 'arcocoseno' debe estar entre -1 y 1".to_string(),
+        });
+    }
+    Ok(respuesta_numero(evaluador, valor.acos()))
+}
+
+fn metodo_arcotangente(
+    evaluador: &mut Evaluador,
+    _objeto: &Valor,
+    argumentos: &[Valor],
+    linea: usize,
+) -> ResultadoQuetzal<ResultadoMetodoObjetoNativo> {
+    verificar_argumentos_exactos(argumentos, 1, linea)?;
+    let valor = extraer_numero(argumentos, 0, linea, "valor")?;
+    Ok(respuesta_numero(evaluador, valor.atan()))
+}
+
+fn metodo_hipotenusa(
+    evaluador: &mut Evaluador,
+    _objeto: &Valor,
+    argumentos: &[Valor],
+    linea: usize,
+) -> ResultadoQuetzal<ResultadoMetodoObjetoNativo> {
+    verificar_argumentos_exactos(argumentos, 2, linea)?;
+    let cateto_a = extraer_numero(argumentos, 0, linea, "primer cateto")?;
+    let cateto_b = extraer_numero(argumentos, 1, linea, "segundo cateto")?;
+    Ok(respuesta_numero(evaluador, cateto_a.hypot(cateto_b)))
+}
+
+fn metodo_logaritmo(
+    evaluador: &mut Evaluador,
+    _objeto: &Valor,
+    argumentos: &[Valor],
+    linea: usize,
+) -> ResultadoQuetzal<ResultadoMetodoObjetoNativo> {
+    verificar_argumentos_exactos(argumentos, 1, linea)?;
+    let valor = extraer_numero(argumentos, 0, linea, "valor")?;
+
+    if valor <= 0.0 {
+        return Err(ErrorQuetzal::ErrorEjecucion {
+            linea,
+            mensaje: "El argumento de 'logaritmo' debe ser mayor que 0".to_string(),
+        });
+    }
+
+    Ok(respuesta_numero(evaluador, valor.ln()))
+}
+
+fn metodo_logaritmo_base(
+    evaluador: &mut Evaluador,
+    _objeto: &Valor,
+    argumentos: &[Valor],
+    linea: usize,
+) -> ResultadoQuetzal<ResultadoMetodoObjetoNativo> {
+    verificar_argumentos_exactos(argumentos, 2, linea)?;
+    let valor = extraer_numero(argumentos, 0, linea, "valor")?;
+    let base = extraer_numero(argumentos, 1, linea, "base")?;
+
+    if valor <= 0.0 {
+        return Err(ErrorQuetzal::ErrorEjecucion {
+            linea,
+            mensaje: "El argumento de 'logaritmo_base' debe ser mayor que 0".to_string(),
+        });
+    }
+
+    if base <= 0.0 || (base - 1.0).abs() < f64::EPSILON {
+        return Err(ErrorQuetzal::ErrorEjecucion {
+            linea,
+            mensaje: "La base del logaritmo debe ser positiva y distinta de 1".to_string(),
+        });
+    }
+
+    Ok(respuesta_numero(evaluador, valor.log(base)))
+}
+
+fn metodo_logaritmo10(
+    evaluador: &mut Evaluador,
+    _objeto: &Valor,
+    argumentos: &[Valor],
+    linea: usize,
+) -> ResultadoQuetzal<ResultadoMetodoObjetoNativo> {
+    verificar_argumentos_exactos(argumentos, 1, linea)?;
+    let valor = extraer_numero(argumentos, 0, linea, "valor")?;
+
+    if valor <= 0.0 {
+        return Err(ErrorQuetzal::ErrorEjecucion {
+            linea,
+            mensaje: "El argumento de 'logaritmo10' debe ser mayor que 0".to_string(),
+        });
+    }
+
+    Ok(respuesta_numero(evaluador, valor.log10()))
+}
+
+fn metodo_exponencial(
+    evaluador: &mut Evaluador,
+    _objeto: &Valor,
+    argumentos: &[Valor],
+    linea: usize,
+) -> ResultadoQuetzal<ResultadoMetodoObjetoNativo> {
+    verificar_argumentos_exactos(argumentos, 1, linea)?;
+    let valor = extraer_numero(argumentos, 0, linea, "valor")?;
+    let resultado = valor.exp();
+
+    if !resultado.is_finite() {
+        return Err(ErrorQuetzal::ErrorEjecucion {
+            linea,
+            mensaje: "El resultado de 'exponencial' no es un número finito".to_string(),
+        });
+    }
+
+    Ok(respuesta_numero(evaluador, resultado))
+}
+
+fn metodo_maximo(
+    evaluador: &mut Evaluador,
+    _objeto: &Valor,
+    argumentos: &[Valor],
+    linea: usize,
+) -> ResultadoQuetzal<ResultadoMetodoObjetoNativo> {
+    verificar_argumentos_exactos(argumentos, 1, linea)?;
+    let numeros = extraer_lista_numeros(argumentos, 0, linea, "maximo")?;
+    let maximo =
+        numeros
+            .into_iter()
+            .reduce(f64::max)
+            .ok_or_else(|| ErrorQuetzal::ErrorEjecucion {
+                linea,
+                mensaje: "No se puede calcular el máximo de una lista vacía".to_string(),
+            })?;
+    Ok(respuesta_numero(evaluador, maximo))
+}
+
+fn metodo_minimo(
+    evaluador: &mut Evaluador,
+    _objeto: &Valor,
+    argumentos: &[Valor],
+    linea: usize,
+) -> ResultadoQuetzal<ResultadoMetodoObjetoNativo> {
+    verificar_argumentos_exactos(argumentos, 1, linea)?;
+    let numeros = extraer_lista_numeros(argumentos, 0, linea, "minimo")?;
+    let minimo =
+        numeros
+            .into_iter()
+            .reduce(f64::min)
+            .ok_or_else(|| ErrorQuetzal::ErrorEjecucion {
+                linea,
+                mensaje: "No se puede calcular el mínimo de una lista vacía".to_string(),
+            })?;
+    Ok(respuesta_numero(evaluador, minimo))
+}
+
+fn metodo_promedio(
+    evaluador: &mut Evaluador,
+    _objeto: &Valor,
+    argumentos: &[Valor],
+    linea: usize,
+) -> ResultadoQuetzal<ResultadoMetodoObjetoNativo> {
+    verificar_argumentos_exactos(argumentos, 1, linea)?;
+    let numeros = extraer_lista_numeros(argumentos, 0, linea, "promedio")?;
+    let suma: f64 = numeros.iter().sum();
+    Ok(respuesta_numero(evaluador, suma / numeros.len() as f64))
+}
+
+fn metodo_suma_total(
+    evaluador: &mut Evaluador,
+    _objeto: &Valor,
+    argumentos: &[Valor],
+    linea: usize,
+) -> ResultadoQuetzal<ResultadoMetodoObjetoNativo> {
+    verificar_argumentos_exactos(argumentos, 1, linea)?;
+    let numeros = extraer_lista_numeros(argumentos, 0, linea, "suma_total")?;
+    let suma: f64 = numeros.iter().sum();
+    Ok(respuesta_numero(evaluador, suma))
+}
+
+fn metodo_producto_total(
+    evaluador: &mut Evaluador,
+    _objeto: &Valor,
+    argumentos: &[Valor],
+    linea: usize,
+) -> ResultadoQuetzal<ResultadoMetodoObjetoNativo> {
+    verificar_argumentos_exactos(argumentos, 1, linea)?;
+    let numeros = extraer_lista_numeros(argumentos, 0, linea, "producto_total")?;
+    let producto = numeros.into_iter().product();
+    Ok(respuesta_numero(evaluador, producto))
+}
+
+fn metodo_grados_a_radianes(
+    evaluador: &mut Evaluador,
+    _objeto: &Valor,
+    argumentos: &[Valor],
+    linea: usize,
+) -> ResultadoQuetzal<ResultadoMetodoObjetoNativo> {
+    verificar_argumentos_exactos(argumentos, 1, linea)?;
+    let grados = extraer_numero(argumentos, 0, linea, "grados")?;
+    Ok(respuesta_numero(evaluador, grados * PI / 180.0))
+}
+
+fn metodo_radianes_a_grados(
+    evaluador: &mut Evaluador,
+    _objeto: &Valor,
+    argumentos: &[Valor],
+    linea: usize,
+) -> ResultadoQuetzal<ResultadoMetodoObjetoNativo> {
+    verificar_argumentos_exactos(argumentos, 1, linea)?;
+    let radianes = extraer_numero(argumentos, 0, linea, "radianes")?;
+    Ok(respuesta_numero(evaluador, radianes * 180.0 / PI))
+}
+
+fn verificar_argumentos_exactos(
+    argumentos: &[Valor],
+    esperados: usize,
+    linea: usize,
+) -> ResultadoQuetzal<()> {
+    if argumentos.len() != esperados {
+        return Err(ErrorQuetzal::ArgumentosIncorrectos {
+            linea,
+            esperados,
+            recibidos: argumentos.len(),
+        });
+    }
+    Ok(())
+}
+
+fn extraer_numero(
+    argumentos: &[Valor],
+    indice: usize,
+    linea: usize,
+    nombre_argumento: &str,
+) -> ResultadoQuetzal<f64> {
+    match argumentos.get(indice) {
+        Some(Valor::Entero(entero)) => Ok(*entero as f64),
+        Some(Valor::Numero(numero)) => Ok(*numero),
         _ => Err(ErrorQuetzal::ErrorTipo {
             linea,
-            mensaje: format!("El argumento '{}' debe ser un número", nombre),
+            mensaje: format!(
+                "El argumento '{}' debe ser numérico para el módulo Matemática",
+                nombre_argumento
+            ),
         }),
     }
+}
+
+fn extraer_entero(
+    argumentos: &[Valor],
+    indice: usize,
+    linea: usize,
+    nombre_argumento: &str,
+) -> ResultadoQuetzal<i64> {
+    match argumentos.get(indice) {
+        Some(Valor::Entero(entero)) => Ok(*entero),
+        Some(Valor::Numero(numero)) => {
+            let aproximado = redondear_interno(*numero);
+            if (aproximado.fract()).abs() < f64::EPSILON {
+                Ok(aproximado as i64)
+            } else {
+                Err(ErrorQuetzal::ErrorTipo {
+                    linea,
+                    mensaje: format!(
+                        "El argumento '{}' debe ser un entero para el módulo Matemática",
+                        nombre_argumento
+                    ),
+                })
+            }
+        }
+        _ => Err(ErrorQuetzal::ErrorTipo {
+            linea,
+            mensaje: format!(
+                "El argumento '{}' debe ser un entero para el módulo Matemática",
+                nombre_argumento
+            ),
+        }),
+    }
+}
+
+fn extraer_lista_numeros(
+    argumentos: &[Valor],
+    indice: usize,
+    linea: usize,
+    metodo: &str,
+) -> ResultadoQuetzal<Vec<f64>> {
+    match argumentos.get(indice) {
+        Some(Valor::Lista(elementos)) => {
+            if elementos.is_empty() {
+                return Err(ErrorQuetzal::ErrorEjecucion {
+                    linea,
+                    mensaje: format!(
+                        "El método '{}' requiere una lista con al menos un número",
+                        metodo
+                    ),
+                });
+            }
+
+            let mut numeros = Vec::with_capacity(elementos.len());
+            for (posicion, valor) in elementos.iter().enumerate() {
+                match valor {
+                    Valor::Entero(entero) => numeros.push(*entero as f64),
+                    Valor::Numero(numero) => numeros.push(*numero),
+                    _ => {
+                        return Err(ErrorQuetzal::ErrorTipo {
+                            linea,
+                            mensaje: format!(
+                                "El argumento 'elemento {}' debe ser numérico para el módulo Matemática",
+                                posicion + 1
+                            ),
+                        });
+                    }
+                }
+            }
+            Ok(numeros)
+        }
+        _ => Err(ErrorQuetzal::ErrorTipo {
+            linea,
+            mensaje: format!("El método '{}' requiere una lista de números", metodo),
+        }),
+    }
+}
+
+fn respuesta_numero(evaluador: &Evaluador, numero: f64) -> ResultadoMetodoObjetoNativo {
+    ResultadoMetodoObjetoNativo::sin_cambios(Valor::Numero(evaluador.redondear_numero(numero)))
+}
+
+fn redondear_interno(valor: f64) -> f64 {
+    const FACTOR: f64 = 1e15;
+    (valor * FACTOR).round() / FACTOR
+}
+
+/// Construye el objeto Matemática con sus constantes y metadatos
+fn construir_objeto_matematica(evaluador: &Evaluador) -> Variable {
+    let mut propiedades = HashMap::new();
+    let mut propiedades_publicas = Vec::new();
+
+    // Constantes matemáticas comunes expuestas como propiedades públicas
+    let constantes = [
+        ("PI", evaluador.redondear_numero(PI)),
+        ("TAU", evaluador.redondear_numero(TAU)),
+        ("E", evaluador.redondear_numero(E)),
+    ];
+
+    for (nombre, valor) in constantes {
+        propiedades_publicas.push(nombre.to_string());
+        propiedades.insert(nombre.to_string(), Valor::Numero(valor));
+    }
+
+    // Marcar internamente el tipo de objeto para facilitar su identificación
+    propiedades.insert(
+        "__nombre".to_string(),
+        Valor::Texto(NOMBRE_OBJETO_MATEMATICA.to_string()),
+    );
+
+    let metodos_publicos = METODOS_MATEMATICA
+        .iter()
+        .map(|nombre| nombre.to_string())
+        .collect();
+
+    let valor_objeto = Valor::Objeto {
+        clase: NOMBRE_OBJETO_MATEMATICA.to_string(),
+        propiedades,
+        propiedades_publicas,
+        metodos_publicos,
+    };
+
+    Variable::nueva(
+        NOMBRE_OBJETO_MATEMATICA.to_string(),
+        valor_objeto,
+        TipoVariable::Inmutable,
+        "objeto".to_string(),
+    )
 }


### PR DESCRIPTION
## Resumen
- añadir un registro genérico de métodos nativos de objetos dentro del evaluador
- migrar toda la lógica del módulo Matemática al propio registrador nativo usando ese mecanismo
- registrar automáticamente todos los métodos del objeto Matemática sin modificar el núcleo

## Pruebas
- `cargo fmt`
- `cargo test`


------
https://chatgpt.com/codex/tasks/task_e_68d379c5cb08832fb9da1449d23019a7